### PR TITLE
fix: make sure a build happens before a release

### DIFF
--- a/package.json
+++ b/package.json
@@ -9,6 +9,7 @@
     "check-coverage": "jest --coverage",
     "commit": "git-cz",
     "report-coverage": "codecov",
+    "presemantic-release": "npm run build",
     "semantic-release": "semantic-release",
     "tdd": "jest --watch",
     "test": "jest"


### PR DESCRIPTION
this will ensure that the dist file is included in the npm package, fixing #41